### PR TITLE
Added props for break-view classname, text and content.

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,11 +144,17 @@ HTML
 </div>
 ```
 
-### Customize prev and next button inner HTML (experimental)
-You can customize the inner HTML of previous and next button with `slot` tag.
-The name of the previous and next button is `prevContent` and `nextContent`.
+### Customize button HTML (experimental)
+You can customize the inner HTML of the previous button, next button, and break view indicator, with the `slot` tag.
 
-Example
+**Slot names**
+| Name | Description |
+| --- | --- |
+| `prevContent` | Previous button |
+| `nextContent` | Next button |
+| `breakViewContent` | Break view indicator |
+
+**Example**
 ```html
 <paginate
   :page-count="10"
@@ -159,6 +165,13 @@ Example
 
   <span slot="prevContent">Changed previous button</span>
   <span slot="nextContent">Changed next button</span>
+  <span slot="breakViewContent">
+    <svg width="16" height="4" viewBox="0 0 16 4">
+      <circle fill="#999999" cx="2" cy="2" r="2" />
+      <circle fill="#999999" cx="8" cy="2" r="2" />
+      <circle fill="#999999" cx="14" cy="2" r="2" />
+    </svg>
+  </span>
 
 </paginate>
 ```
@@ -172,6 +185,7 @@ Example
 | `margin-pages` | `Number` | The number of displayed pages for margins. **default: 1** |
 | `prev-text` | `String` | Text for the previous button. **default: Prev**  |
 | `next-text` | `String` | Text for the next button. **default: Next**  |
+| `break-view-text` | `String` | Text for the break view button. **default: `…`**  |
 | `initial-page` | `Number` | The index of initial page which selected. **default: 0** |
 | `force-page` | `Number` | The index of overridden selected page. |
 | `click-handler` | `Function` | The method to call when page clicked. Use clicked page number as parameter. |
@@ -182,6 +196,8 @@ Example
 | `prev-link-class` | `String` | CSS class name for tag `a` of `previous` element. |
 | `next-class` | `String` | CSS class name for tag `li` of `next` element. |
 | `next-link-class` | `String` | CSS class name for tag `a` of `next` element. |
+| `break-view-class` | `String` | CSS class name for tag `li` of `break view` element. |
+| `break-view-link-class` | `String` | CSS class name for tag `a` of `break view` element. |
 | `active-class` | `String` | CSS class name for active page element. **default: active** |
 | `disabled-class` | `String` | CSS class name for disabled page element. **default: disabled** |
 | `no-li-surround` | `Boolean` | Support no `li` tag surround `a` tag. **default: false** |

--- a/demo/App.vue
+++ b/demo/App.vue
@@ -17,6 +17,8 @@
         :prev-link-class="'prev-link-item'"
         :next-class="'next-item'"
         :next-link-class="'next-link-item'"
+        :break-view-class="'break-view'"
+        :break-view-link-class="'break-view-link'"
       ></paginate>
     </div>
 
@@ -32,8 +34,36 @@
         :page-link-class="'item'"
         :prev-link-class="'item'"
         :next-link-class="'item'"
+        :break-view-link-class="'break-view-link'"
         :no-li-surround="true"
       ></paginate>
+    </div>
+    
+    <div>
+      <h3>Pagination component with SVG for view break</h3>
+      <paginate
+        :page-count="20"
+        :margin-pages="2"
+        :page-range="4"
+        :initial-page="0"
+        :container-class="'pagination'"
+        :page-class="'page-item'"
+        :page-link-class="'page-link-item'"
+        :prev-class="'prev-item'"
+        :prev-link-class="'prev-link-item'"
+        :next-class="'next-item'"
+        :next-link-class="'next-link-item'"
+        :break-view-class="'break-view'"
+        :break-view-link-class="'break-view-link'"
+      >
+        <span slot="breakViewContent">
+          <svg width="16" height="4" viewBox="0 0 16 4">
+            <circle fill="#999999" cx="2" cy="2" r="2" />
+            <circle fill="#999999" cx="8" cy="2" r="2" />
+            <circle fill="#999999" cx="14" cy="2" r="2" />
+          </svg>
+        </span>
+      </paginate>
     </div>
   </div>
 </template>
@@ -55,5 +85,9 @@ export default {
 .next-item {
 }
 .next-link-item {
+}
+.break-view {
+}
+.break-view-item {
 }
 </style>

--- a/src/components/Paginate.vue
+++ b/src/components/Paginate.vue
@@ -8,8 +8,9 @@
       <a @click="prevPage()" @keyup.enter="prevPage()" :class="prevLinkClass" tabindex="0"><slot name="prevContent">{{ prevText }}</slot></a>
     </li>
 
-    <li v-for="page in pages" :class="[pageClass, page.selected ? activeClass : '', page.disabled ? disabledClass : '']">
-      <a v-if="page.disabled" :class="pageLinkClass" tabindex="0">{{ page.content }}</a>
+    <li v-for="page in pages" :class="[pageClass, page.selected ? activeClass : '', page.disabled ? disabledClass : '', page.breakView ? breakViewClass: '']">
+      <a v-if="page.breakView" :class="[pageLinkClass, breakViewLinkClass]" tabindex="0"><slot name="breakViewContent">{{ breakViewText }}</slot></a>
+      <a v-else-if="page.disabled" :class="pageLinkClass" tabindex="0">{{ page.content }}</a>
       <a v-else @click="handlePageSelected(page.index)" @keyup.enter="handlePageSelected(page.index)" :class="pageLinkClass" tabindex="0">{{ page.content }}</a>
     </li>
 
@@ -26,8 +27,9 @@
     <a v-if="firstLastButton" @click="selectFirstPage()" @keyup.enter="selectFirstPage()" :class="[pageLinkClass, firstPageSelected() ? disabledClass : '']" tabindex="0">{{ firstButtonText }}</a>
     <a @click="prevPage()" @keyup.enter="prevPage()" :class="[prevLinkClass, firstPageSelected() ? disabledClass : '']" tabindex="0"><slot name="prevContent">{{ prevText }}</slot></a>
     <template v-for="page in pages">
-      <a v-if="page.disabled" :class="[pageLinkClass, page.selected ? activeClass : '', page.disabled ? disabledClass : '']" tabindex="0">{{ page.content }}</a>
-      <a v-else @click="handlePageSelected(page.index)" @keyup.enter="handlePageSelected(page.index)" :class="[pageLinkClass, page.selected ? activeClass : '', page.disabled ? disabledClass : '']" tabindex="0">{{ page.content }}</a>
+      <a v-if="page.breakView" :class="[pageLinkClass, breakViewLinkClass, page.disabled ? disabledClass : '']" tabindex="0"><slot name="breakViewContent">{{ breakViewText }}</slot></a>
+      <a v-else-if="page.disabled" :class="[pageLinkClass, page.selected ? activeClass : '', disabledClass]" tabindex="0">{{ page.content }}</a>
+      <a v-else @click="handlePageSelected(page.index)" @keyup.enter="handlePageSelected(page.index)" :class="[pageLinkClass, page.selected ? activeClass : '']" tabindex="0">{{ page.content }}</a>
     </template>
     <a @click="nextPage()" @keyup.enter="nextPage()" :class="[nextLinkClass, lastPageSelected() ? disabledClass : '']" tabindex="0"><slot name="nextContent">{{ nextText }}</slot></a>
     <a v-if="firstLastButton" @click="selectLastPage()" @keyup.enter="selectLastPage()" :class="[pageLinkClass, lastPageSelected() ? disabledClass : '']" tabindex="0">{{ lastButtonText }}</a>
@@ -68,6 +70,10 @@ export default {
       type: String,
       default: 'Next'
     },
+    breakViewText: {
+      type: String,
+      default: '…'
+    },
     containerClass: {
       type: String
     },
@@ -87,6 +93,12 @@ export default {
       type: String
     },
     nextLinkClass: {
+      type: String
+    },
+    breakViewClass: {
+      type: String
+    },
+    breakViewLinkClass: {
       type: String
     },
     activeClass: {
@@ -161,8 +173,8 @@ export default {
 
         let setBreakView = index => {
           let breakView = {
-            content: '...',
-            disabled: true
+            disabled: true,
+            breakView: true
           }
 
           items[index] = breakView

--- a/test/components/paginate_spec.js
+++ b/test/components/paginate_spec.js
@@ -121,10 +121,12 @@ describe('Paginate', () => {
       const vm = new Component({
         propsData: {
           pageCount: 10,
-          initialPage: 9
+          initialPage: 9,
+          breakViewClass: 'break-view'
         }
       }).$mount()
-      expect(vm.$el.querySelector(`li:nth-child(3) a`).textContent).to.equal('...')
+      expect(vm.$el.querySelectorAll(`li:nth-child(3).break-view`).length).to.equal(1)
+      expect(vm.$el.querySelector(`li:nth-child(3) a`).textContent).to.equal('…')
       expect(vm.$el.querySelector(`li:nth-child(4) a`).textContent).to.equal('7')
     })
   })
@@ -183,4 +185,25 @@ describe('Paginate', () => {
       // })
     })
   })
+
+  it('Use custom text', () => {
+    const vm = new Component({
+      propsData: {
+        pageCount: 10,
+        prevClass: 'prev-item',
+        nextClass: 'next-item',
+        breakViewClass: 'break-view',
+        prevText: 'PREVIOUS TEXT',
+        nextText: 'NEXT TEXT',
+        breakViewText: 'BREAK VIEW TEXT'
+      }
+    }).$mount()
+    const prevButton = vm.$el.querySelector('.prev-item')
+    const nextButton = vm.$el.querySelector('.next-item')
+    const breakView = vm.$el.querySelector('.break-view')
+    expect(prevButton.textContent).to.equal('PREVIOUS TEXT')
+    expect(nextButton.textContent).to.equal('NEXT TEXT')
+    expect(breakView.textContent).to.equal('BREAK VIEW TEXT')
+  })
+
 })


### PR DESCRIPTION
Currently there is no classname around the break-view element (...). This PR adds the ability to set a classname on the element li and anchor.

It also allows the text and content, in the break-view element to be set.